### PR TITLE
FIX：エリアデータを階層構造に修正

### DIFF
--- a/src/app/Models/Area.php
+++ b/src/app/Models/Area.php
@@ -3,9 +3,12 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Kalnoy\Nestedset\NodeTrait;
 
 class Area extends Model
 {
+    use NodeTrait;
+
     protected $fillable = [
         'name',
     ];

--- a/src/composer.json
+++ b/src/composer.json
@@ -14,6 +14,7 @@
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^1.0",
         "guzzlehttp/guzzle": "^6.3",
+        "kalnoy/nestedset": "^5.0",
         "laravel/framework": "^7.0",
         "laravel/tinker": "^2.0",
         "laravel/ui": "^2.0"

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c15006159802dbde2f92a6c32ef2d414",
+    "content-hash": "c3c31ff90ba7d8b3890a6c7d642f1dec",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1038,6 +1038,65 @@
                 "url"
             ],
             "time": "2019-07-01T23:21:34+00:00"
+        },
+        {
+            "name": "kalnoy/nestedset",
+            "version": "v5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lazychaser/laravel-nestedset.git",
+                "reference": "d4fe17f9abd3414014bda32a5612c9ed24246f99"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lazychaser/laravel-nestedset/zipball/d4fe17f9abd3414014bda32a5612c9ed24246f99",
+                "reference": "d4fe17f9abd3414014bda32a5612c9ed24246f99",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "~5.7.0|~5.8.0|^6.0|^7.0",
+                "illuminate/events": "~5.7.0|~5.8.0|^6.0|^7.0",
+                "illuminate/support": "~5.7.0|~5.8.0|^6.0|^7.0",
+                "php": ">=7.1.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "7.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "v5.0.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Kalnoy\\Nestedset\\NestedSetServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kalnoy\\Nestedset\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexander Kalnoy",
+                    "email": "lazychaser@gmail.com"
+                }
+            ],
+            "description": "Nested Set Model for Laravel 5.7 and up",
+            "keywords": [
+                "database",
+                "hierarchy",
+                "laravel",
+                "nested sets",
+                "nsm"
+            ],
+            "time": "2020-03-04T05:33:20+00:00"
         },
         {
             "name": "laravel/framework",

--- a/src/database/migrations/2020_04_19_035029_create_areas_table.php
+++ b/src/database/migrations/2020_04_19_035029_create_areas_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Kalnoy\Nestedset\NestedSet;
 
 class CreateAreasTable extends Migration
 {
@@ -16,6 +17,7 @@ class CreateAreasTable extends Migration
         Schema::create('areas', function (Blueprint $table) {
             $table->id();
             $table->string('name');
+            NestedSet::columns($table);
             $table->timestamps();
         });
     }

--- a/src/database/seeds/common/AreasTableSeeder.php
+++ b/src/database/seeds/common/AreasTableSeeder.php
@@ -9,19 +9,41 @@ use GuzzleHttp\Client;
 
 class AreasTableSeeder extends Seeder
 {
+    const AREA_DATA = [
+        '東京エリア' => [
+            '新宿・代々木',
+            '渋谷',
+            '銀座・日比谷・有楽町・新橋',
+            '原宿・青山・表参道',
+            '六本木・麻布・広尾',
+            '赤坂・溜池山王',
+            '恵比寿・代官山・中目黒',
+            '田町・浜松町・芝浦・品川',
+            '東京・日本橋',
+            '目黒・白金台・五反田・大崎',
+            '市ヶ谷・四谷・麹町・九段',
+            'お台場・有明',
+            '天王洲・港南',
+            'その他地域',
+        ],
+        '神奈川エリア' => [
+            '横浜',
+            '川崎',
+            '鎌倉・逗子・横須賀',
+            '藤沢・茅ヶ崎・平塚',
+            '相模原',
+            'その他地域',
+        ],
+    ];
+
     public function run()
     {
-        // 駅情報取得APIを利用して山手線の駅名を取得
-        $client = new HeartRailsExpressClient();
-        $response = $client->getYamanoteLineStations();
-        $body = $response->getBody();
-        $data = json_decode($body, true);
-        $stations = $data['response']['station'];
-        foreach ($stations as $stationData) {
-            $stationName = $stationData['name'];
-            Area::firstOrCreate([
-                'name' => $stationName
-            ]);
-        }
+        collect(self::AREA_DATA)->each(function ($areas, $prefecture) {
+            $area = Area::create(['name' => $prefecture]);
+
+            collect($areas)->each(function ($areaData) use ($area) {
+                $area->children()->create(['name' => $areaData]);
+            });
+        });        
     }
 }


### PR DESCRIPTION
resolve #128

## 実装内容
- エリアデータを階層構造になるよう修正しました。
- laravel nestedを導入(kalnoy/nestedset)
- seeder(AreasTableSeeder)に、下記スプレッドシートを参考にエリアデータを投入
- migration(area)の更新

### 残課題
- エリアデータは下記スプレッドシートを参考にデータ投入してますが、最新のエリアデータがあれば、そちらへの差し替えが必要。
https://docs.google.com/spreadsheets/d/16CqR3efXfXMrTsATHrM34qPG4kbRoe_fmHgRKYmlGdQ/edit#gid=1874845988
- migrationファイルを更新したため、本番環境への反映時にmigraitonの更新が必要になります。

### 備考
- 
