### PR TITLE
#99 webpackの再ビルド後に、ブラウザ更新をかける

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -2137,6 +2137,12 @@
                 }
             }
         },
+        "after": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+            "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+            "dev": true
+        },
         "aggregate-error": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -2442,6 +2448,12 @@
                 "is-string": "^1.0.4"
             }
         },
+        "arraybuffer.slice": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+            "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+            "dev": true
+        },
         "arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -2519,6 +2531,12 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
             "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+            "dev": true
+        },
+        "async-each-series": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
+            "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
             "dev": true
         },
         "async-limiter": {
@@ -2991,6 +3009,12 @@
                 "babel-plugin-transform-vue-jsx": "^3.5.0"
             }
         },
+        "backo2": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+            "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+            "dev": true
+        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -3058,10 +3082,22 @@
                 }
             }
         },
+        "base64-arraybuffer": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+            "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+            "dev": true
+        },
         "base64-js": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
             "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+            "dev": true
+        },
+        "base64id": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+            "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
             "dev": true
         },
         "batch": {
@@ -3075,6 +3111,15 @@
             "resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
             "integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg=",
             "dev": true
+        },
+        "better-assert": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+            "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+            "dev": true,
+            "requires": {
+                "callsite": "1.0.0"
+            }
         },
         "big.js": {
             "version": "5.2.2",
@@ -3097,6 +3142,12 @@
             "requires": {
                 "file-uri-to-path": "1.0.0"
             }
+        },
+        "blob": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+            "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
+            "dev": true
         },
         "bluebird": {
             "version": "3.7.2",
@@ -3336,6 +3387,374 @@
             "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
             "dev": true
         },
+        "browser-sync": {
+            "version": "2.26.10",
+            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.10.tgz",
+            "integrity": "sha512-JeVQP3CARvNA1DELj+ZGWj+/0pzE8+Omvq1WNgzaTXVdP3lNEbGxZbkjvLK7hHpQywjQ1sDJWlJQZT6V59XDTg==",
+            "dev": true,
+            "requires": {
+                "browser-sync-client": "^2.26.10",
+                "browser-sync-ui": "^2.26.10",
+                "bs-recipes": "1.3.4",
+                "bs-snippet-injector": "^2.0.1",
+                "chokidar": "^3.4.1",
+                "connect": "3.6.6",
+                "connect-history-api-fallback": "^1",
+                "dev-ip": "^1.0.1",
+                "easy-extender": "^2.3.4",
+                "eazy-logger": "^3",
+                "etag": "^1.8.1",
+                "fresh": "^0.5.2",
+                "fs-extra": "3.0.1",
+                "http-proxy": "^1.18.1",
+                "immutable": "^3",
+                "localtunnel": "^2.0.0",
+                "micromatch": "^4.0.2",
+                "opn": "5.3.0",
+                "portscanner": "2.1.1",
+                "qs": "6.2.3",
+                "raw-body": "^2.3.2",
+                "resp-modifier": "6.0.2",
+                "rx": "4.1.0",
+                "send": "0.16.2",
+                "serve-index": "1.9.1",
+                "serve-static": "1.13.2",
+                "server-destroy": "1.0.1",
+                "socket.io": "2.1.1",
+                "ua-parser-js": "^0.7.18",
+                "yargs": "^15.4.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chokidar": {
+                    "version": "3.4.1",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
+                    "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "~3.1.1",
+                        "braces": "~3.0.2",
+                        "fsevents": "~2.1.2",
+                        "glob-parent": "~5.1.0",
+                        "is-binary-path": "~2.1.0",
+                        "is-glob": "~4.0.1",
+                        "normalize-path": "~3.0.0",
+                        "readdirp": "~3.4.0"
+                    }
+                },
+                "cliui": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+                    "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^6.2.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "emoji-regex": {
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "fs-extra": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+                    "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^3.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                },
+                "http-errors": {
+                    "version": "1.6.3",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+                    "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+                    "dev": true,
+                    "requires": {
+                        "depd": "~1.1.2",
+                        "inherits": "2.0.3",
+                        "setprototypeof": "1.1.0",
+                        "statuses": ">= 1.4.0 < 2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "jsonfile": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+                    "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6"
+                    }
+                },
+                "mime": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+                    "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "opn": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+                    "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+                    "dev": true,
+                    "requires": {
+                        "is-wsl": "^1.1.0"
+                    }
+                },
+                "qs": {
+                    "version": "6.2.3",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+                    "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
+                    "dev": true
+                },
+                "send": {
+                    "version": "0.16.2",
+                    "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+                    "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "depd": "~1.1.2",
+                        "destroy": "~1.0.4",
+                        "encodeurl": "~1.0.2",
+                        "escape-html": "~1.0.3",
+                        "etag": "~1.8.1",
+                        "fresh": "0.5.2",
+                        "http-errors": "~1.6.2",
+                        "mime": "1.4.1",
+                        "ms": "2.0.0",
+                        "on-finished": "~2.3.0",
+                        "range-parser": "~1.2.0",
+                        "statuses": "~1.4.0"
+                    }
+                },
+                "serve-static": {
+                    "version": "1.13.2",
+                    "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+                    "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+                    "dev": true,
+                    "requires": {
+                        "encodeurl": "~1.0.2",
+                        "escape-html": "~1.0.3",
+                        "parseurl": "~1.3.2",
+                        "send": "0.16.2"
+                    }
+                },
+                "setprototypeof": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+                    "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+                    "dev": true
+                },
+                "statuses": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+                    "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "yargs": {
+                    "version": "15.4.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+                    "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^6.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^4.1.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^4.2.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^18.1.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "browser-sync-client": {
+            "version": "2.26.10",
+            "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.10.tgz",
+            "integrity": "sha512-8pYitKwpVva7hzXJI8lTljNDbA9fjMEobHSxWqegIUon/GjJAG3UgHB/+lBWnOLzTY8rGX66MvGqL1Aknyrj7g==",
+            "dev": true,
+            "requires": {
+                "etag": "1.8.1",
+                "fresh": "0.5.2",
+                "mitt": "^1.1.3",
+                "rxjs": "^5.5.6"
+            },
+            "dependencies": {
+                "rxjs": {
+                    "version": "5.5.12",
+                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+                    "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+                    "dev": true,
+                    "requires": {
+                        "symbol-observable": "1.0.1"
+                    }
+                }
+            }
+        },
+        "browser-sync-ui": {
+            "version": "2.26.10",
+            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.10.tgz",
+            "integrity": "sha512-UfNSBItlXcmEvJ9RE4JooNtIsiIfHowp+7/52Jz4VFfQD4v78QK5/NV9DVrG41oMM3zLyhW4f/RliOb4ysStZg==",
+            "dev": true,
+            "requires": {
+                "async-each-series": "0.1.1",
+                "connect-history-api-fallback": "^1",
+                "immutable": "^3",
+                "server-destroy": "1.0.1",
+                "socket.io-client": "^2.0.4",
+                "stream-throttle": "^0.1.3"
+            }
+        },
+        "browser-sync-webpack-plugin": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/browser-sync-webpack-plugin/-/browser-sync-webpack-plugin-2.2.2.tgz",
+            "integrity": "sha512-x92kl8LdBi4dp6YVXYqrSoDkOCOLCeBOrYSY0h9Sk1VcCDSoZC1Vc62eae6TfC2ljN4/L+aYlkzE46kirHzbgA==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4"
+            }
+        },
         "browserify-aes": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -3447,6 +3866,18 @@
                 "escalade": "^3.0.1",
                 "node-releases": "^1.1.58"
             }
+        },
+        "bs-recipes": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
+            "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU=",
+            "dev": true
+        },
+        "bs-snippet-injector": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/bs-snippet-injector/-/bs-snippet-injector-2.0.1.tgz",
+            "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
+            "dev": true
         },
         "buffer": {
             "version": "4.9.2",
@@ -3568,6 +3999,12 @@
             "requires": {
                 "caller-callsite": "^2.0.0"
             }
+        },
+        "callsite": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+            "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+            "dev": true
         },
         "callsites": {
             "version": "3.1.0",
@@ -4045,10 +4482,22 @@
             "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
             "dev": true
         },
+        "component-bind": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+            "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+            "dev": true
+        },
         "component-emitter": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
             "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+            "dev": true
+        },
+        "component-inherit": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+            "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
             "dev": true
         },
         "compose-function": {
@@ -4132,6 +4581,56 @@
             "dev": true,
             "requires": {
                 "globs": "^0.1.2"
+            }
+        },
+        "connect": {
+            "version": "3.6.6",
+            "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+            "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "finalhandler": "1.1.0",
+                "parseurl": "~1.3.2",
+                "utils-merge": "1.0.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "finalhandler": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+                    "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "encodeurl": "~1.0.1",
+                        "escape-html": "~1.0.3",
+                        "on-finished": "~2.3.0",
+                        "parseurl": "~1.3.2",
+                        "statuses": "~1.3.1",
+                        "unpipe": "~1.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "statuses": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+                    "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+                    "dev": true
+                }
             }
         },
         "connect-history-api-fallback": {
@@ -4988,6 +5487,12 @@
                 }
             }
         },
+        "dev-ip": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
+            "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
+            "dev": true
+        },
         "diffie-hellman": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -5196,6 +5701,24 @@
                 "stream-shift": "^1.0.0"
             }
         },
+        "easy-extender": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
+            "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.10"
+            }
+        },
+        "eazy-logger": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
+            "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
+            "dev": true,
+            "requires": {
+                "tfunk": "^3.0.1"
+            }
+        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5282,6 +5805,110 @@
             "dev": true,
             "requires": {
                 "once": "^1.4.0"
+            }
+        },
+        "engine.io": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
+            "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
+            "dev": true,
+            "requires": {
+                "accepts": "~1.3.4",
+                "base64id": "1.0.0",
+                "cookie": "0.3.1",
+                "debug": "~3.1.0",
+                "engine.io-parser": "~2.1.0",
+                "ws": "~3.3.1"
+            },
+            "dependencies": {
+                "cookie": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+                    "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "engine.io-parser": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+                    "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+                    "dev": true,
+                    "requires": {
+                        "after": "0.8.2",
+                        "arraybuffer.slice": "~0.0.7",
+                        "base64-arraybuffer": "0.1.5",
+                        "blob": "0.0.5",
+                        "has-binary2": "~1.0.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "ws": {
+                    "version": "3.3.3",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+                    "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+                    "dev": true,
+                    "requires": {
+                        "async-limiter": "~1.0.0",
+                        "safe-buffer": "~5.1.0",
+                        "ultron": "~1.1.0"
+                    }
+                }
+            }
+        },
+        "engine.io-client": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.3.tgz",
+            "integrity": "sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==",
+            "dev": true,
+            "requires": {
+                "component-emitter": "~1.3.0",
+                "component-inherit": "0.0.3",
+                "debug": "~4.1.0",
+                "engine.io-parser": "~2.2.0",
+                "has-cors": "1.1.0",
+                "indexof": "0.0.1",
+                "parseqs": "0.0.5",
+                "parseuri": "0.0.5",
+                "ws": "~6.1.0",
+                "xmlhttprequest-ssl": "~1.5.4",
+                "yeast": "0.1.2"
+            },
+            "dependencies": {
+                "ws": {
+                    "version": "6.1.4",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+                    "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+                    "dev": true,
+                    "requires": {
+                        "async-limiter": "~1.0.0"
+                    }
+                }
+            }
+        },
+        "engine.io-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
+            "integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
+            "dev": true,
+            "requires": {
+                "after": "0.8.2",
+                "arraybuffer.slice": "~0.0.7",
+                "base64-arraybuffer": "0.1.5",
+                "blob": "0.0.5",
+                "has-binary2": "~1.0.2"
             }
         },
         "enhanced-resolve": {
@@ -6814,6 +7441,29 @@
                 "ansi-regex": "^2.0.0"
             }
         },
+        "has-binary2": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+            "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+            "dev": true,
+            "requires": {
+                "isarray": "2.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+                    "dev": true
+                }
+            }
+        },
+        "has-cors": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+            "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+            "dev": true
+        },
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -7329,6 +7979,12 @@
             "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==",
             "dev": true
         },
+        "immutable": {
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+            "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
+            "dev": true
+        },
         "import-cwd": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -7399,6 +8055,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
             "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+            "dev": true
+        },
+        "indexof": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+            "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
             "dev": true
         },
         "infer-owner": {
@@ -7824,6 +8486,15 @@
                         "is-buffer": "^1.1.5"
                     }
                 }
+            }
+        },
+        "is-number-like": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
+            "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
+            "dev": true,
+            "requires": {
+                "lodash.isfinite": "^3.3.2"
             }
         },
         "is-obj": {
@@ -8448,6 +9119,12 @@
                 "leven": "^3.1.0"
             }
         },
+        "limiter": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+            "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
+            "dev": true
+        },
         "lines-and-columns": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -8482,6 +9159,95 @@
                 }
             }
         },
+        "localtunnel": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-2.0.0.tgz",
+            "integrity": "sha512-g6E0aLgYYDvQDxIjIXkgJo2+pHj3sGg4Wz/XP3h2KtZnRsWPbOQY+hw1H8Z91jep998fkcVE9l+kghO+97vllg==",
+            "dev": true,
+            "requires": {
+                "axios": "0.19.0",
+                "debug": "4.1.1",
+                "openurl": "1.1.1",
+                "yargs": "13.3.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "axios": {
+                    "version": "0.19.0",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+                    "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+                    "dev": true,
+                    "requires": {
+                        "follow-redirects": "1.5.10",
+                        "is-buffer": "^2.0.2"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "is-buffer": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+                    "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "yargs": {
+                    "version": "13.3.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+                    "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^5.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.1"
+                    }
+                }
+            }
+        },
         "locate-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -8502,6 +9268,12 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+            "dev": true
+        },
+        "lodash.isfinite": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
+            "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
             "dev": true
         },
         "lodash.memoize": {
@@ -8921,6 +9693,12 @@
                 "stream-each": "^1.1.0",
                 "through2": "^2.0.0"
             }
+        },
+        "mitt": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
+            "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
+            "dev": true
         },
         "mixin-deep": {
             "version": "1.3.2",
@@ -12754,6 +13532,12 @@
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
             "dev": true
         },
+        "object-component": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+            "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
+            "dev": true
+        },
         "object-copy": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -12999,6 +13783,12 @@
                 }
             }
         },
+        "openurl": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
+            "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=",
+            "dev": true
+        },
         "opn": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -13197,6 +13987,24 @@
             "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
             "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
             "dev": true
+        },
+        "parseqs": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+            "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+            "dev": true,
+            "requires": {
+                "better-assert": "~1.0.0"
+            }
+        },
+        "parseuri": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+            "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+            "dev": true,
+            "requires": {
+                "better-assert": "~1.0.0"
+            }
         },
         "parseurl": {
             "version": "1.3.3",
@@ -13431,6 +14239,24 @@
                     "requires": {
                         "ms": "^2.1.1"
                     }
+                }
+            }
+        },
+        "portscanner": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
+            "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
+            "dev": true,
+            "requires": {
+                "async": "1.5.2",
+                "is-number-like": "^1.0.3"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "dev": true
                 }
             }
         },
@@ -15147,6 +15973,33 @@
                 }
             }
         },
+        "resp-modifier": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
+            "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
+            "dev": true,
+            "requires": {
+                "debug": "^2.2.0",
+                "minimatch": "^3.0.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
         "restore-cursor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -15238,6 +16091,12 @@
             "requires": {
                 "aproba": "^1.1.1"
             }
+        },
+        "rx": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+            "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+            "dev": true
         },
         "rxjs": {
             "version": "6.6.0",
@@ -15508,6 +16367,12 @@
                 "parseurl": "~1.3.3",
                 "send": "0.17.1"
             }
+        },
+        "server-destroy": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+            "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
+            "dev": true
         },
         "set-blocking": {
             "version": "2.0.0",
@@ -15833,6 +16698,201 @@
                 }
             }
         },
+        "socket.io": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
+            "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+            "dev": true,
+            "requires": {
+                "debug": "~3.1.0",
+                "engine.io": "~3.2.0",
+                "has-binary2": "~1.0.2",
+                "socket.io-adapter": "~1.1.0",
+                "socket.io-client": "2.1.1",
+                "socket.io-parser": "~3.2.0"
+            },
+            "dependencies": {
+                "component-emitter": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+                    "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "engine.io-client": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+                    "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+                    "dev": true,
+                    "requires": {
+                        "component-emitter": "1.2.1",
+                        "component-inherit": "0.0.3",
+                        "debug": "~3.1.0",
+                        "engine.io-parser": "~2.1.1",
+                        "has-cors": "1.1.0",
+                        "indexof": "0.0.1",
+                        "parseqs": "0.0.5",
+                        "parseuri": "0.0.5",
+                        "ws": "~3.3.1",
+                        "xmlhttprequest-ssl": "~1.5.4",
+                        "yeast": "0.1.2"
+                    }
+                },
+                "engine.io-parser": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+                    "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+                    "dev": true,
+                    "requires": {
+                        "after": "0.8.2",
+                        "arraybuffer.slice": "~0.0.7",
+                        "base64-arraybuffer": "0.1.5",
+                        "blob": "0.0.5",
+                        "has-binary2": "~1.0.2"
+                    }
+                },
+                "isarray": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "socket.io-client": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+                    "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+                    "dev": true,
+                    "requires": {
+                        "backo2": "1.0.2",
+                        "base64-arraybuffer": "0.1.5",
+                        "component-bind": "1.0.0",
+                        "component-emitter": "1.2.1",
+                        "debug": "~3.1.0",
+                        "engine.io-client": "~3.2.0",
+                        "has-binary2": "~1.0.2",
+                        "has-cors": "1.1.0",
+                        "indexof": "0.0.1",
+                        "object-component": "0.0.3",
+                        "parseqs": "0.0.5",
+                        "parseuri": "0.0.5",
+                        "socket.io-parser": "~3.2.0",
+                        "to-array": "0.1.4"
+                    }
+                },
+                "socket.io-parser": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+                    "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+                    "dev": true,
+                    "requires": {
+                        "component-emitter": "1.2.1",
+                        "debug": "~3.1.0",
+                        "isarray": "2.0.1"
+                    }
+                },
+                "ws": {
+                    "version": "3.3.3",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+                    "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+                    "dev": true,
+                    "requires": {
+                        "async-limiter": "~1.0.0",
+                        "safe-buffer": "~5.1.0",
+                        "ultron": "~1.1.0"
+                    }
+                }
+            }
+        },
+        "socket.io-adapter": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
+            "integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g==",
+            "dev": true
+        },
+        "socket.io-client": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
+            "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
+            "dev": true,
+            "requires": {
+                "backo2": "1.0.2",
+                "base64-arraybuffer": "0.1.5",
+                "component-bind": "1.0.0",
+                "component-emitter": "1.2.1",
+                "debug": "~4.1.0",
+                "engine.io-client": "~3.4.0",
+                "has-binary2": "~1.0.2",
+                "has-cors": "1.1.0",
+                "indexof": "0.0.1",
+                "object-component": "0.0.3",
+                "parseqs": "0.0.5",
+                "parseuri": "0.0.5",
+                "socket.io-parser": "~3.3.0",
+                "to-array": "0.1.4"
+            },
+            "dependencies": {
+                "component-emitter": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+                    "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+                    "dev": true
+                }
+            }
+        },
+        "socket.io-parser": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+            "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+            "dev": true,
+            "requires": {
+                "component-emitter": "1.2.1",
+                "debug": "~3.1.0",
+                "isarray": "2.0.1"
+            },
+            "dependencies": {
+                "component-emitter": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+                    "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
         "sockjs": {
             "version": "0.3.20",
             "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.20.tgz",
@@ -16092,6 +17152,24 @@
             "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
             "dev": true
         },
+        "stream-throttle": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+            "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
+            "dev": true,
+            "requires": {
+                "commander": "^2.2.0",
+                "limiter": "^1.0.5"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                    "dev": true
+                }
+            }
+        },
         "string-width": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -16305,6 +17383,12 @@
                 }
             }
         },
+        "symbol-observable": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+            "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+            "dev": true
+        },
         "symbol.prototype.description": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/symbol.prototype.description/-/symbol.prototype.description-1.0.2.tgz",
@@ -16446,6 +17530,49 @@
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
         },
+        "tfunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
+            "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.1",
+                "object-path": "^0.9.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "object-path": {
+                    "version": "0.9.2",
+                    "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
+                    "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
         "throttle-debounce": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.2.1.tgz",
@@ -16504,6 +17631,12 @@
             "requires": {
                 "os-tmpdir": "~1.0.2"
             }
+        },
+        "to-array": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+            "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+            "dev": true
         },
         "to-arraybuffer": {
             "version": "1.0.1",
@@ -16629,6 +17762,12 @@
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
             "dev": true
         },
+        "ua-parser-js": {
+            "version": "0.7.21",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+            "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
+            "dev": true
+        },
         "uglify-js": {
             "version": "3.4.10",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
@@ -16652,6 +17791,12 @@
                     "dev": true
                 }
             }
+        },
+        "ultron": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+            "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+            "dev": true
         },
         "unfetch": {
             "version": "4.1.0",
@@ -17903,6 +19048,12 @@
                 "async-limiter": "~1.0.0"
             }
         },
+        "xmlhttprequest-ssl": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+            "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+            "dev": true
+        },
         "xtend": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -18078,6 +19229,12 @@
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
             }
+        },
+        "yeast": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+            "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+            "dev": true
         }
     }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -16,6 +16,8 @@
         "@storybook/vue": "^5.3.19",
         "axios": "^0.19",
         "babel-preset-vue": "^2.0.2",
+        "browser-sync": "^2.26.10",
+        "browser-sync-webpack-plugin": "^2.2.2",
         "cross-env": "^7.0",
         "deepmerge": "^4.2.2",
         "fibers": "^5.0.0",

--- a/src/webpack.mix.js
+++ b/src/webpack.mix.js
@@ -26,4 +26,16 @@ glob.sync(`${scssPath}/**/*.scss`).map(function(file) {
     mix.sass(file, publicPath + css_path);
 });
 
+/**
+ * browerSync(ブラウザ自動リロード)設定
+ */
+mix.browserSync({
+    proxy: {
+        target: "localhost:90",
+    },
+    files: [
+        publicPath + '**/*.*',
+    ],
+});
+
 mix.version();


### PR DESCRIPTION
resolve #99

## 実装内容
- webpackビルド後（public/配下変更後）に、ブラウザ更新をかけるようbrowserSyncを導入。
  ・package.jsonに`browser-sync` `browser-sync-webpack-plugin` を追加
  ・webpack.min.jsにbrowserSyncの定義を追加

### 残課題
- なし

### 備考
- `npm run hot` を実行した状態で、`npm run dev`等によりwebpack更新すると、ブラウザ自動更新が走る認識で導入してます。
