### PR TITLE
LoginControllerの修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,11 +111,11 @@ jobs:
           command: docker-compose run laravel php artisan migrate --seed
           name: test seeder reentrant
       - run:
-          command: docker-compose run laravel composer install --no-dev
-          name: test prod install
-      - run:
           command: docker-compose run laravel php artisan route:list
           name: test route:list
+      - run:
+          command: docker-compose run laravel composer install --no-dev
+          name: test prod install
 
   phpunit:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,9 @@ jobs:
       - run:
           command: docker-compose run laravel composer install --no-dev
           name: test prod install
+      - run:
+          command: docker-compose run laravel php artisan route:list
+          name: test route:list
 
   phpunit:
     machine: true

--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -3,12 +3,9 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
-use App\Models\Gym;
-use App\Models\Trainer;
-use App\Providers\RouteServiceProvider;
-use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use App\Http\Requests\LoginRequest;
 use Illuminate\Http\Request;
-use Illuminate\Routing\Route;
+use Illuminate\Foundation\Auth\AuthenticatesUsers;
 
 class LoginController extends Controller
 {
@@ -23,31 +20,13 @@ class LoginController extends Controller
     |
     */
 
-    use AuthenticatesUsers;
+    use AuthenticatesUsers {
+        AuthenticatesUsers::login as doLogin;
+    }
 
-    /**
-     * Where to redirect users after login.
-     *
-     * @var string
-     */
-    protected $redirectTo = RouteServiceProvider::HOME;
-
-    /** @var string */
-    private $userType;
-
-    /**
-     * LoginController constructor.
-     * @param Route $route
-     */
-    public function __construct(Route $route)
+    public function login(LoginRequest $request)
     {
-        $this->middleware('guest')->except('logout');
-        // トレーナー、ジムオーナーで処理を分ける可能性があるためコンストラクタで設定する
-        $this->userType = strpos($route->getName(), 'trainers') !== false ? Trainer::class : Gym::class;
-
-        if ($route->getName() === 'gyms.login') {
-            $this->redirectTo = route('gyms.index');
-        }
+        return $this->doLogin($request);
     }
 
     /**
@@ -55,6 +34,20 @@ class LoginController extends Controller
      */
     protected function credentials(Request $request)
     {
-        return array_merge($request->only('email', 'password'), ['user_type' => $this->userType]);
+        return array_merge(
+            $request->only('email', 'password'),
+            ['user_type' => $request->user_type]
+        );
+    }
+
+    protected function redirectTo()
+    {
+        // TODO: #59 ホーム画面を実装する
+        // $login = auth()->user();
+        // if ($login->user_type === App\Models\Gym::class) {
+        //     return route('gyms.index');
+        // }
+
+        return route('top');
     }
 }

--- a/src/app/Http/Requests/LoginRequest.php
+++ b/src/app/Http/Requests/LoginRequest.php
@@ -24,6 +24,7 @@ class LoginRequest extends FormRequest
     public function rules()
     {
         return [
+            'user_type' => 'required|string',
             'email' => 'required|string|email',
             'password' => 'required|string',
         ];

--- a/src/app/Models/Login.php
+++ b/src/app/Models/Login.php
@@ -34,7 +34,8 @@ class Login extends Authenticatable implements MustVerifyEmail
      * @var array
      */
     protected $hidden = [
-        'password', 'remember_token',
+        'password',
+        'remember_token',
     ];
 
     /**

--- a/src/resources/views/components/common/_loginForm.blade.php
+++ b/src/resources/views/components/common/_loginForm.blade.php
@@ -7,6 +7,11 @@
                 <div class="card-body">
                     <form method="POST" action="{{ $isGym ? route('gyms.login') : route('trainers.login') }}">
                         @csrf
+                        <input
+                            type="hidden"
+                            name="user_type"
+                            value="{{ $isGym ? \App\Models\Gym::class : \App\Models\Trainer::class }}"
+                        >
 
                         <div class="form-group row">
                             <label for="email"

--- a/src/tests/Feature/LoginTest.php
+++ b/src/tests/Feature/LoginTest.php
@@ -26,7 +26,11 @@ class LoginTest extends TestCase
     {
         $trainer = factory(Trainer::class)->create();
 
-        $response = $this->post(route('trainers.login', ['email' => $trainer->login->email, 'password' => 'password']));
+        $response = $this->post(route('trainers.login', [
+            'email' => $trainer->login->email,
+            'password' => 'password',
+            'user_type' => Trainer::class,
+        ]));
 
         $response->assertStatus(302);
         $this->assertAuthenticated();
@@ -39,7 +43,11 @@ class LoginTest extends TestCase
     {
         $owner = factory(Gym::class)->create();
 
-        $response = $this->post(route('gyms.login', ['email' => $owner->login->email, 'password' => 'password']));
+        $response = $this->post(route('gyms.login', [
+            'email' => $owner->login->email,
+            'password' => 'password',
+            'user_type' => Gym::class,
+        ]));
 
         $response->assertStatus(302);
         $this->assertAuthenticated();


### PR DESCRIPTION
resolve #163

## 実装内容
- ログインコントローラの修正
    - requestのバリデーションが効かないエラーの修正
    - 送信前のルートに依存する点を修正
         - requestにuser_typeを含める
- `php artisan route:list` ができないバグの修正

### 残課題
- ログイン後のホーム画面を実装する
- ログインのルートが分散している
    - #165

### 備考
- 
