### PR TITLE
#189 オファーメール送信判定修正

### DIFF
--- a/src/app/Mail/OfferRecieve.php
+++ b/src/app/Mail/OfferRecieve.php
@@ -2,9 +2,9 @@
 
 namespace App\Mail;
 
+use App\Models\Login;
 use App\Models\Offer;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 
@@ -13,14 +13,18 @@ class OfferRecieve extends Mailable
     use Queueable, SerializesModels;
 
     public $offer;
+    
+    private $sendToUser;
+
     /**
-     * Create a new message instance.
-     *
-     * @return void
+     * OfferRecieve constructor.
+     * @param Offer $offer
+     * @param Login $sendToUser
      */
-    public function __construct(Offer $offer)
+    public function __construct(Offer $offer, Login $sendToUser)
     {
         $this->offer = $offer;
+        $this->sendToUser = $sendToUser;
     }
 
     /**
@@ -30,10 +34,11 @@ class OfferRecieve extends Mailable
      */
     public function build()
     {
-        return $this->subject('オファー受信のお知らせ')
-            ->markdown('markdown.offers.recieve')
+        return $this->subject($this->offer->getMailSubjectByUser($this->sendToUser))
+            ->view($this->offer->getMailTemplate())
             ->with([
-                'url' => route('offers.show', $this->offer->id)
+                'offer' => $this->offer,
+                'sendToUser' => $this->sendToUser
             ]);
     }
 }

--- a/src/app/Models/Offer.php
+++ b/src/app/Models/Offer.php
@@ -84,15 +84,48 @@ class Offer extends Model
      * 現在のオファー状態を元にメール送信先を取得
      * @return array
      */
-    public function getSendMailAddresses()
+    public function getSendMailUsers()
     {
         $result = [];
         if ($this->state->should_notice_trainer) {
-            $result[] = $this->trainer->email;
+            $result[] = $this->trainer;
         }
         if ($this->state->should_notice_gym) {
-            $result[] = $this->gym->email;
+            $result[] = $this->gym;
         }
         return $result;
+    }
+
+    /**
+     * メールタイトル取得
+     * @param Login $type
+     * @return \Illuminate\Config\Repository|\Illuminate\Contracts\Foundation\Application|mixed
+     */
+    public function getMailSubjectByUser(Login $type)
+    {
+        switch ($this->offer_state_id) {
+            case OfferState::ENTRY:
+                return config('mail.subject.offers.entry.' . $type->user_type);
+            case OfferState::OFFER:
+                return config('mail.subject.offers.offer.' . $type->user_type);
+            default:
+                throw app(\Exception::class, ['message' => 'invalid offer state']);
+        }
+    }
+
+    /**
+     * メールテンプレート取得
+     * @return string
+     */
+    public function getMailTemplate()
+    {
+        switch ($this->offer_state_id) {
+            case OfferState::ENTRY:
+                return 'mails.offers.entry';
+            case OfferState::OFFER:
+                return 'mails.offers.offer';
+            default:
+                throw app(\Exception::class, ['message' => 'invalid offer state']);
+        }
     }
 }

--- a/src/app/Observers/OfferObserver.php
+++ b/src/app/Observers/OfferObserver.php
@@ -20,9 +20,11 @@ class OfferObserver
         // ユーザーに受信メール送信
         // 登録後のOfferStateを取得するためにfreshを行う
         $stored_offer = $offer->fresh();
-        $send_address = $stored_offer->getSendMailAddresses();
 
-        $mail = app(OfferRecieve::class, ['offer' => $stored_offer]);
-        $offer->notify(app(OfferNotify::class, ['mail' => $mail, 'to' => $send_address]));
+        $sendUsers = $stored_offer->getSendMailUsers();
+        foreach ($sendUsers as $sendUser) {
+            $mail = app(OfferRecieve::class, ['offer' => $stored_offer, 'sendToUser' => $sendUser]);
+            $stored_offer->notify(app(OfferNotify::class, ['mail' => $mail, 'to' => [$sendUser->email]]));
+        }
     }
 }

--- a/src/config/mail.php
+++ b/src/config/mail.php
@@ -111,4 +111,16 @@ return [
         ],
     ],
 
+    'subject' => [
+        'offers' => [
+            'entry' => [
+                App\Models\Trainer::class => '【BorderlessGYM（ボーダーレスジム）】ジムへのエントリーを受け付けました',
+                App\Models\Gym::class => '【BorderlessGYM（ボーダーレスジム）】トレーナーからエントリーが届きました！'
+            ],
+            'offer' => [
+                App\Models\Trainer::class => '【BorderlessGYM（ボーダーレスジム）】ジムからオファーが届きました！',
+                App\Models\Gym::class => '【BorderlessGYM（ボーダーレスジム）】トレーナーへのオファーを受け付けました'
+            ],
+        ],
+    ],
 ];


### PR DESCRIPTION
resolve #189

## 実装内容
- オファーメールのステータス毎の送信判定処理を修正(サーバー側)

### 残課題
- メール本文の当て込み

### 備考
- メールタイトルはいい管理方法が浮かばなかったのでconfigで持つようにしました 💦 
