### PR TITLE
ジム登録コマンドの結果にgym_idも表示する

### DIFF
--- a/src/app/Console/Commands/GymCreateCommand.php
+++ b/src/app/Console/Commands/GymCreateCommand.php
@@ -99,6 +99,7 @@ class GymCreateCommand extends Command
         ]);
 
         $this->info('登録が完了しました');
+        $this->info("ID：$gym->id");
         $this->info("パスワード：$password");
     }
 }

--- a/src/database/seeds/CommonSeeder.php
+++ b/src/database/seeds/CommonSeeder.php
@@ -16,6 +16,7 @@ class CommonSeeder extends Seeder
             Common\AreasTableSeeder::class,
             Common\OccupationsTableSeeder::class,
             Common\PrefecturesTableSeeder::class,
+            Common\OfferStateSeeder::class,
         ]);
     }
 }

--- a/src/database/seeds/TestingSeeder.php
+++ b/src/database/seeds/TestingSeeder.php
@@ -15,7 +15,6 @@ class TestingSeeder extends Seeder
         $this->call([
             Testing\GymsTableSeeder::class,
             Testing\TrainersTableSeeder::class,
-            Testing\OfferStateSeeder::class,
         ]);
     }
 }

--- a/src/database/seeds/common/AreasTableSeeder.php
+++ b/src/database/seeds/common/AreasTableSeeder.php
@@ -39,10 +39,10 @@ class AreasTableSeeder extends Seeder
     public function run()
     {
         collect(self::AREA_DATA)->each(function ($areas, $prefecture) {
-            $area = Area::create(['name' => $prefecture]);
+            $area = Area::firstOrCreate(['name' => $prefecture]);
 
             collect($areas)->each(function ($areaData) use ($area) {
-                $area->children()->create(['name' => $areaData]);
+                $area->children()->firstOrCreate(['name' => $areaData]);
             });
         });
     }

--- a/src/database/seeds/common/OfferStateSeeder.php
+++ b/src/database/seeds/common/OfferStateSeeder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Database\Seeds\Testing;
+namespace Database\Seeds\Common;
 
 use App\Models\OfferState;
 use Illuminate\Database\Seeder;


### PR DESCRIPTION
# 実装内容
- ジムの登録コマンドの結果にgyms.idも表示する
    - アカウント管理の易化のため
    - 各種クエリの生成を楽にするため
- seederのバグ修正
    - areasが無限にできるバグの修正
    - offer_statesが登録されないバグの修正

### 残課題
- 本番での動作確認

### 備考
- 
