### PR TITLE
#105 SCSSのベンダープリフィックスを自動でつける

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -36,5 +36,8 @@
     "dependencies": {
         "vuetify": "^2.3.4",
         "vuex": "^3.5.1"
-    }
+    },
+    "browserslist": [
+        "defaults"
+    ]
 }


### PR DESCRIPTION
resolve #105

## 実装内容
- package.jsonにbrowserlistの設定を追加

### 残課題
- 特になし

### 備考
- browserlistは"default"に設定してますが（defaultだと以下の設定になる認識）、サポート範囲を広げた方がいい or 狭めた方がいい等ありましたら、ご指摘ください。

<<補足>>
| 設定 | 概要 |
| --- | --- |
| 0.5% | 世界の使用状況統計を使用で0.5%以上 |
| last 2 versions  | 各ブラウザの最後の2つのバージョン |
| Firefox ESR | 最新の「Firefox Extended Support Release」バージョン |
| not dead | 24ヶ月以内にアップデートされているバージョンのブラウザ |
